### PR TITLE
Fix alpha color calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ dist/
 venv/
 *.egg-info/
 **/node_modules/
+
+poetry.lock
+pyproject.toml
+.vscode

--- a/streamlit_antd_components/Menu/frontend/src/custom.react.js
+++ b/streamlit_antd_components/Menu/frontend/src/custom.react.js
@@ -128,26 +128,41 @@ const getCollapseKeys = (items) => {
 }
 
 const AlphaColor = (varColor = '--primary-color', alpha = 0.1) => {
-    let pc = getComputedStyle(document.querySelector(":root")).getPropertyValue(varColor)
-    let reg = /^#([0-9a-fA-f]{3}|[0-9a-fA-f]{6})$/;
-    let sColor = pc.toLowerCase();
-    if (sColor && reg.test(sColor)) {
-        if (sColor.length === 4) {
-            let sColorNew = "#";
-            for (let i = 1; i < 4; i += 1) {
-                sColorNew += sColor.slice(i, i + 1).concat(sColor.slice(i, i + 1));
+    const getColorComponents = (color) => {
+        // Handle hexadecimal color format
+        const hexMatch = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+        if (hexMatch.test(color)) {
+            let hex = color.substring(1);
+            if (hex.length === 3) {
+                hex = hex.split('').map((char) => char + char).join('');
             }
-            sColor = sColorNew;
+            const [r, g, b] = hex.match(/.{2}/g).map((c) => parseInt(c, 16));
+            return [r, g, b];
         }
-        let sColorChange = [];
-        for (let i = 1; i < 7; i += 2) {
-            sColorChange.push(parseInt(`0x${sColor.slice(i, i + 2)}`));
+
+        // Handle RGB and RGBA color formats
+        const rgbMatch = /^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*[\d.]+)?\)$/;
+        const match = color.match(rgbMatch);
+        if (match) {
+            const [_, r, g, b] = match.map(Number);
+            return [r, g, b];
         }
-        return `rgba(${sColorChange.join(",")},${alpha})`;
+
+        // Handle other color formats or invalid colors
+        return null;
+    };
+
+    const color = getComputedStyle(document.documentElement).getPropertyValue(varColor).trim();
+    const colorComponents = getColorComponents(color);
+
+    if (colorComponents) {
+        const [r, g, b] = colorComponents;
+        return `rgba(${r}, ${g}, ${b}, ${alpha})`;
     } else {
-        return sColor;
+        // Handle invalid colors
+        return 'defaultColor';
     }
-}
+};
 
 
 export {strToNode, AlphaColor, getParent, getHrefKeys, getCollapseKeys, menuHeight}

--- a/streamlit_antd_components/Tree/frontend/src/custom.react.js
+++ b/streamlit_antd_components/Tree/frontend/src/custom.react.js
@@ -23,26 +23,42 @@ const strToNode = (obj) => {
 }
 
 const AlphaColor = (varColor = '--primary-color', alpha = 0.2) => {
-    let pc = getComputedStyle(document.querySelector(":root")).getPropertyValue(varColor)
-    let reg = /^#([0-9a-fA-f]{3}|[0-9a-fA-f]{6})$/;
-    let sColor = pc.toLowerCase();
-    if (sColor && reg.test(sColor)) {
-        if (sColor.length === 4) {
-            let sColorNew = "#";
-            for (let i = 1; i < 4; i += 1) {
-                sColorNew += sColor.slice(i, i + 1).concat(sColor.slice(i, i + 1));
+    const getColorComponents = (color) => {
+        // Handle hexadecimal color format
+        const hexMatch = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+        if (hexMatch.test(color)) {
+            let hex = color.substring(1);
+            if (hex.length === 3) {
+                hex = hex.split('').map((char) => char + char).join('');
             }
-            sColor = sColorNew;
+            const [r, g, b] = hex.match(/.{2}/g).map((c) => parseInt(c, 16));
+            return [r, g, b];
         }
-        let sColorChange = [];
-        for (let i = 1; i < 7; i += 2) {
-            sColorChange.push(parseInt(`0x${sColor.slice(i, i + 2)}`));
+
+        // Handle RGB and RGBA color formats
+        const rgbMatch = /^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*[\d.]+)?\)$/;
+        const match = color.match(rgbMatch);
+        if (match) {
+            const [_, r, g, b] = match.map(Number);
+            return [r, g, b];
         }
-        return `rgba(${sColorChange.join(",")},${alpha})`;
+
+        // Handle other color formats or invalid colors
+        return null;
+    };
+
+    const color = getComputedStyle(document.documentElement).getPropertyValue(varColor).trim();
+    const colorComponents = getColorComponents(color);
+
+    if (colorComponents) {
+        const [r, g, b] = colorComponents;
+        return `rgba(${r}, ${g}, ${b}, ${alpha})`;
     } else {
-        return sColor;
+        // Handle invalid colors
+        return 'defaultColor';
     }
-}
+};
+
 
 //all parent keys
 const getParents = (keys, obj) => {


### PR DESCRIPTION
This PR updates the method which calculates transparency for a given color and alpha argument.

While the current implementation seems generally correct, it was not working on my system (as per #1) so I refactored it  and added a few changes:
- The `getColorComponents` helper function is introduced to handle different color formats.
- The function uses `document.documentElement` to get the root element instead of `document.querySelector(":root")`.
- The color parsing logic is extended to handle RGB and RGBA color formats in addition to hexadecimal.
- Invalid colors are handled explicitly by returning a default color (another appropriate error handling mechanism can be added later, if needed).