### PR TITLE
feat: add support for custom listStyle in transfer component

### DIFF
--- a/streamlit_antd_components/widgets/transfer.py
+++ b/streamlit_antd_components/widgets/transfer.py
@@ -10,7 +10,6 @@
 """
 from ..utils import *
 
-
 def transfer(
         items: List[str] = None,
         index: List[int] = None,
@@ -27,8 +26,9 @@ def transfer(
         reload: Union[bool, str] = False,
         width: int = None,
         height: int = None,
-        use_container_width=False,
-        return_index=False,
+        listStyle: Dict[str, Any] = None,
+        use_container_width: bool = False,
+        return_index: bool = False,
         on_change: Callable = None,
         args: Tuple[Any, ...] = None,
         kwargs: Dict[str, Any] = None,
@@ -51,6 +51,7 @@ def transfer(
     :param reload: reload button,set str to rename button label
     :param width: width in px
     :param height: height in px
+    :param listStyle: custom style for transfer list (e.g., {'color': 'white'})
     :param use_container_width: makes the transfer stretch its width to match the parent container
     :param return_index: return item index
     :param on_change: item change callback
@@ -61,11 +62,19 @@ def transfer(
     """
     # register callback
     register(key, on_change, args, kwargs)
+    
     # parse items
     items, kv = ParseItems(items, format_func).transfer()
+    
     # component params
-    kw = update_kw(locals(), items=items)
+    kw = update_kw(locals(), items=items, **(kwargs or {}))
+    
+    # Include listStyle explicitly if provided
+    if listStyle:
+        kw['listStyle'] = listStyle
+    
     # component default
     default = get_default(index, return_index, kv)
+    
     # pass component id and params to frontend
     return component(id=get_func_name(), kw=kw, default=default, key=key)


### PR DESCRIPTION
This commit adds support for the listStyle parameter in the transfer component, enabling users to customize the style of the transfer list.

++ Changes Made:
Added listStyle as an optional parameter in the transfer function. Ensured listStyle is included in the component's configuration (kw) when provided. Expanded kwargs to pass additional parameters directly to the component.

++ Usage Example:

transfer(
    items=['Item 1', 'Item 2'],
    index=[0],
    label='Example Transfer',
    listStyle={'color': 'white', 'background': 'black'}
)
This allows users to apply custom styles directly to the transfer list.


++ Why this change?
Improves flexibility and customization of the transfer component. Addresses the need for styling options without requiring further adjustments in the core library.